### PR TITLE
Fix db access queries and backfill ingestion

### DIFF
--- a/common/db_access.py
+++ b/common/db_access.py
@@ -2,21 +2,22 @@
 from __future__ import annotations
 from datetime import datetime
 from typing import List
-from .dbutils import fetch_all
+from .dbutils import query_all
 from .schema import T_MINUTE, T_DAILY, T_TICKS, T_QUOTES, MinuteBar, DailyBar, Tick, Quote
 
 def get_minute_bars(symbol: str, start: datetime, end: datetime, limit: int | None = None) -> List[MinuteBar]:
+    limit_clause = "LIMIT %s" if limit else ""
     q = f"""
         SELECT symbol, ts_utc, open, high, low, close, volume, vwap, trades
         FROM {T_MINUTE}
         WHERE symbol=%s AND ts_utc BETWEEN %s AND %s
         ORDER BY ts_utc ASC
-        { 'LIMIT %s' if limit else '' }
+        {limit_clause}
     """
     params = [symbol, start, end]
     if limit:
         params.append(limit)
-    rows = fetch_all(q, params)
+    rows = query_all(q, params)
     return [MinuteBar(**r) for r in rows]
 
 def get_daily_bars(symbol: str, start: datetime, end: datetime) -> List[DailyBar]:
@@ -26,33 +27,35 @@ def get_daily_bars(symbol: str, start: datetime, end: datetime) -> List[DailyBar
         WHERE symbol=%s AND session_date BETWEEN %s AND %s
         ORDER BY session_date ASC
     """
-    rows = fetch_all(q, [symbol, start, end])
+    rows = query_all(q, [symbol, start, end])
     return [DailyBar(**r) for r in rows]
 
 def get_ticks(symbol: str, start: datetime, end: datetime, limit: int | None = None) -> List[Tick]:
+    limit_clause = "LIMIT %s" if limit else ""
     q = f"""
         SELECT symbol, ts_utc, price, size, exchange
         FROM {T_TICKS}
         WHERE symbol=%s AND ts_utc BETWEEN %s AND %s
         ORDER BY ts_utc ASC
-        { 'LIMIT %s' if limit else '' }
+        {limit_clause}
     """
     params = [symbol, start, end]
     if limit:
         params.append(limit)
-    rows = fetch_all(q, params)
+    rows = query_all(q, params)
     return [Tick(**r) for r in rows]
 
 def get_quotes(symbol: str, start: datetime, end: datetime, limit: int | None = None) -> List[Quote]:
+    limit_clause = "LIMIT %s" if limit else ""
     q = f"""
         SELECT symbol, ts_utc, bid, ask, bid_size, ask_size, exchange
         FROM {T_QUOTES}
         WHERE symbol=%s AND ts_utc BETWEEN %s AND %s
         ORDER BY ts_utc ASC
-        { 'LIMIT %s' if limit else '' }
+        {limit_clause}
     """
     params = [symbol, start, end]
     if limit:
         params.append(limit)
-    rows = fetch_all(q, params)
+    rows = query_all(q, params)
     return [Quote(**r) for r in rows]


### PR DESCRIPTION
## Summary
- replace common.db_access helper usage with the available query_all utility and fix SQL LIMIT clauses
- wire dbmanager backfill to the polygon fetch helpers that exist in poly_tools_decap and normalize data before upserting
- correct the last-market-day helper and pass symbol/records to the db_writer upsert functions in the proper order

## Testing
- python -m compileall common/db_access.py dbmanager/db_backfill.py

------
https://chatgpt.com/codex/tasks/task_e_68e00627f4c483208ad867545ee8d954